### PR TITLE
Update to 2.2.2

### DIFF
--- a/src/passmanager.c
+++ b/src/passmanager.c
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
 		cap_value_t clear_list[1];
 		caps = cap_get_proc();
 		if (caps == NULL) {
-			perror("caps");
+			perror("libcap");
 			exit(1);
 		}
 		cap_list[0] = CAP_IPC_LOCK;
@@ -609,8 +609,8 @@ int main(int argc, char* argv[])
             returnVal = fread(backUpFileBuffer, sizeof(char), returnFileSize(dbFileName), copyFile);
             if (returnVal != returnFileSize(dbFileName) / sizeof(char)) {
                 if (ferror(copyFile)) {
-                    printf("Fread failed\n");
-                    return 1;
+                    perror("backupfile read");
+                    return errno;
                 }
             }
 
@@ -618,8 +618,8 @@ int main(int argc, char* argv[])
             if (returnVal != returnFileSize(dbFileName) / sizeof(char))
             {
                 if (ferror(backUpFile)) {
-                    printf("fwrite failed @ 485\n");
-                    return 1;
+                    perror("backupile write");
+                    return errno;
                 }
             }
             fclose(copyFile);
@@ -639,7 +639,6 @@ int main(int argc, char* argv[])
         /*If dbFile is NULL there was a problem opening it*/
         if (dbFile == NULL) {
             perror(argv[0]); /*Print the error that occured*/
-            cleanUpBuffers();
             return errno; /*Return the error's status code*/
         }
 
@@ -680,7 +679,6 @@ int main(int argc, char* argv[])
                 getPass("Verify password:", entryPassStore);
                 if (strcmp(entryPass, entryPassStore) != 0) {
                     printf("\nPasswords do not match.  Nothing done.\n\n");
-                    cleanUpBuffers();
                     return 1;
                 }
             }
@@ -695,7 +693,6 @@ int main(int argc, char* argv[])
                 getPass("Verify password:", dbPassStore);
                 if (strcmp(dbPass, dbPassStore) != 0) {
                     printf("\nPasswords do not match.  Nothing done.\n\n");
-                    cleanUpBuffers();
                     return 1;
                 }
             }
@@ -704,16 +701,14 @@ int main(int argc, char* argv[])
         /*Note this will be needed before openEnvelope() is called in all modes except Read*/
         /*Do OpenSSL priming operations*/
         if (primeSSL() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         /*If password file exists run openEnvelope on it*/
         if (returnFileSize(dbFileName) > 0) {
             if (openEnvelope() != 0) {
-                cleanUpBuffers();
-                cleanUpFiles();
+
                 return 1;
             }
         } else {
@@ -732,8 +727,7 @@ int main(int argc, char* argv[])
         if (EVP1DataFileTmp == NULL) /*Make sure the file opens*/
         {
             perror(argv[0]);
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return errno;
         }
         chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -760,8 +754,7 @@ int main(int argc, char* argv[])
 
             /*sealEnvelope attaches MAC and encrypts it with OpenSSL*/
             if (sealEnvelope(tmpFile2) != 0) {
-                cleanUpBuffers();
-                cleanUpFiles();
+
                 return 1;
             }
         }
@@ -778,7 +771,6 @@ int main(int argc, char* argv[])
         if (EVP2EncryptedFile == NULL) /*Make sure the file opens*/
         {
             perror(argv[0]);
-            cleanUpBuffers();
             return errno;
         }
 
@@ -786,16 +778,14 @@ int main(int argc, char* argv[])
         if (EVP2DecryptedFile == NULL) /*Make sure the file opens*/
         {
             perror(argv[0]);
-            cleanUpBuffers();
-            printf("Couldn't open file: %s", tmpFile1);
+            printf("Couldn't open file: %s\n", tmpFile1);
             return errno;
         }
         chmod(tmpFile1, S_IRUSR | S_IWUSR);
 
         /*Note no primeSSL() needed before openEnvelope() in Read mode*/
         if (openEnvelope() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
@@ -803,8 +793,8 @@ int main(int argc, char* argv[])
         EVP1DataFileTmp = fopen(tmpFile2, "rb");
         if (EVP1DataFileTmp == NULL) {
             perror(argv[0]);
-            cleanUpBuffers();
-            cleanUpFiles();
+            printf("Couldn't open file: %s\n", tmpFile2);
+
             return errno;
         }
         chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -838,7 +828,6 @@ int main(int argc, char* argv[])
         {
             fclose(dbFile);
             printf("\nNo entry name was specified\n");
-            cleanUpBuffers();
             return 1;
         }
 
@@ -846,22 +835,20 @@ int main(int argc, char* argv[])
 
         /*Do OpenSSL priming operations*/
         if (primeSSL()) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         if (openEnvelope() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         EVP1DataFileTmp = fopen(tmpFile2, "rb+");
         if (EVP1DataFileTmp == NULL) {
             perror(argv[0]);
-            cleanUpBuffers();
-            cleanUpFiles();
+			printf("Couldn't open file: %s\n", tmpFile2);
+			
             return errno;
         }
         chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -881,8 +868,7 @@ int main(int argc, char* argv[])
 
             /*After the password entry was deleted the rest of the passwords were written to a 3rd temporary file which is encrypted by sealEnvelope*/
             if (sealEnvelope(tmpFile3) != 0) {
-                cleanUpBuffers();
-                cleanUpFiles();
+
             }
         }
     } else if (toggle.updateEntry == 1) /*Update an entry name*/
@@ -962,7 +948,6 @@ int main(int argc, char* argv[])
                     getPass("Veryify password:", newEntryPassStore);
                     if (strcmp(newEntryPass, newEntryPassStore) != 0) {
                         printf("\nPasswords do not match.  Nothing done.\n\n");
-                        cleanUpBuffers();
                         return 1;
                     }
                 }
@@ -976,22 +961,20 @@ int main(int argc, char* argv[])
 
         /*Do OpenSSL priming operations*/
         if (primeSSL() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         if (openEnvelope() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         EVP1DataFileTmp = fopen(tmpFile2, "rb+");
         if (EVP1DataFileTmp == NULL) {
             perror(argv[0]);
-            cleanUpBuffers();
-            cleanUpFiles();
+            printf("Couldn't open file: %s\n", tmpFile2);
+
             return errno;
         }
         chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -1012,8 +995,7 @@ int main(int argc, char* argv[])
             }
 
             if (sealEnvelope(tmpFile3) != 0) {
-                cleanUpBuffers();
-                cleanUpFiles();
+
             }
         }
     } else if (toggle.updateEncPass == 1) /*Update the database encryption password*/
@@ -1026,16 +1008,15 @@ int main(int argc, char* argv[])
         }
 
         if (openEnvelope(encCipher2, messageDigest2, dbPass) != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
         EVP1DataFileTmp = fopen(tmpFile2, "rb+");
         if (EVP1DataFileTmp == NULL) {
             perror(argv[0]);
-            cleanUpBuffers();
-            cleanUpFiles();
+            printf("Couldn't open file: %s\n", tmpFile2);
+
             return errno;
         }
         chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -1054,8 +1035,7 @@ int main(int argc, char* argv[])
                 printf("Passwords don't match, not changing.\n");
                 /*If not changing, replace old dbPass back into dbPass*/
                 strcpy(dbPass, dbPassOld);
-                cleanUpBuffers();
-                cleanUpFiles();
+
                 return 1;
             } else {
                 printf("Changed password.\n");
@@ -1098,8 +1078,7 @@ int main(int argc, char* argv[])
             if (strcmp(dbPass, dbPassStore) != 0) {
                 printf("Passwords don't match, not changing.\n");
                 strcpy(dbPass, dbPassOld);
-                cleanUpBuffers();
-                cleanUpFiles();
+
                 return 1;
             } else {
                 printf("Changed password.\n");
@@ -1123,8 +1102,7 @@ int main(int argc, char* argv[])
         /*Do OpenSSL priming operations*/
         /*This will change to the cipher just specified*/
         if (primeSSL() != 0) {
-            cleanUpBuffers();
-            cleanUpFiles();
+
             return 1;
         }
 
@@ -1135,8 +1113,7 @@ int main(int argc, char* argv[])
 
         if (updateEncPassResult == 0) {
             if (sealEnvelope(tmpFile3) != 0) {
-                cleanUpBuffers();
-                cleanUpFiles();
+
                 return 1;
             }
         }
@@ -1145,9 +1122,7 @@ int main(int argc, char* argv[])
         printSyntax("passmanager"); /*Just in case something else happens...*/
         return 1;
     }
-
-    cleanUpBuffers();
-    cleanUpFiles();
+    
     return 0;
 }
 
@@ -1177,8 +1152,8 @@ int printPasses(FILE* dbFile, char* searchString)
     returnVal = fread(encryptedBuffer, sizeof(unsigned char), fileSize, dbFile);
     if (returnVal != fileSize / sizeof(unsigned char)) {
         if (ferror(dbFile)) {
-            printf("Fread failed in printPasses\n");
-            return 1;
+            perror("printPasses fread encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1194,8 +1169,7 @@ int printPasses(FILE* dbFile, char* searchString)
         free(passBuffer);
         free(encryptedBuffer);
         free(decryptedBuffer);
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
 
@@ -1211,8 +1185,7 @@ int printPasses(FILE* dbFile, char* searchString)
         free(decryptedBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -1229,8 +1202,7 @@ int printPasses(FILE* dbFile, char* searchString)
         free(decryptedBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     outlen += tmplen;
@@ -1313,8 +1285,8 @@ int updateEntry(FILE* dbFile, char* searchString)
     returnVal = fread(encryptedBuffer, sizeof(unsigned char), fileSize, dbFile);
     if (returnVal != fileSize / sizeof(unsigned char)) {
         if (ferror(dbFile)) {
-            printf("Fread failed in updatePass()\n");
-            return 1;
+            perror("updateEntry fread encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1332,8 +1304,7 @@ int updateEntry(FILE* dbFile, char* searchString)
         free(encryptedBuffer);
         free(decryptedBuffer);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
 
@@ -1356,8 +1327,7 @@ int updateEntry(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -1375,8 +1345,7 @@ int updateEntry(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     outlen += tmplen;
@@ -1496,8 +1465,7 @@ int updateEntry(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -1514,8 +1482,7 @@ int updateEntry(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     outlen += tmplen;
@@ -1536,7 +1503,8 @@ int updateEntry(FILE* dbFile, char* searchString)
     /*Write the modified cipher-text to this temporary file for sealEnvelope()*/
     tmpFile = fopen(tmpFile3, "wb");
     if (tmpFile == NULL) {
-        perror("passmanager");
+        perror("updateEntry fwrite tmpFile3");
+        printf("Couldn't open file: %s\n", tmpFile3);
         return errno;
     }
     chmod(tmpFile3, S_IRUSR | S_IWUSR);
@@ -1546,8 +1514,8 @@ int updateEntry(FILE* dbFile, char* searchString)
     if (returnVal != fileSize / sizeof(unsigned char))
     {
         if (ferror(tmpFile)) {
-            printf("fwrite failed @ 1365\n");
-            return 1;
+            perror("updateEntry fwrite encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1594,8 +1562,8 @@ int deletePass(FILE* dbFile, char* searchString)
     returnVal = fread(encryptedBuffer, sizeof(unsigned char), fileSize, dbFile);
     if (returnVal != fileSize / sizeof(unsigned char)) {
         if (ferror(dbFile)) {
-            printf("Fread failed in deletePass()\n");
-            return 1;
+            perror("deletePass fread encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1612,8 +1580,7 @@ int deletePass(FILE* dbFile, char* searchString)
         free(passBuffer);
         free(encryptedBuffer);
         free(decryptedBuffer);
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
 
@@ -1637,8 +1604,7 @@ int deletePass(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -1656,8 +1622,7 @@ int deletePass(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     outlen += tmplen;
@@ -1728,8 +1693,6 @@ int deletePass(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
         return 1;
     }
     /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -1746,8 +1709,7 @@ int deletePass(FILE* dbFile, char* searchString)
         free(fileBuffer);
         free(ctx);
 
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
     outlen += tmplen;
@@ -1762,7 +1724,8 @@ int deletePass(FILE* dbFile, char* searchString)
     /*Write the modified cipher-text to this temporary file for sealEnvelope()*/
     tmpFile = fopen(tmpFile3, "wb");
     if (tmpFile == NULL) {
-        perror("passmanager");
+        perror("deletePass fwrite tmpFile3");
+        printf("Couldn't open file: %s\n", tmpFile3);
         return errno;
     }
     chmod(tmpFile3, S_IRUSR | S_IWUSR);
@@ -1773,8 +1736,8 @@ int deletePass(FILE* dbFile, char* searchString)
         if (returnVal != fileSize / sizeof(unsigned char))
         {
             if (ferror(tmpFile)) {
-                printf("fwrite failed @ 1550\n");
-                return 1;
+                perror("deletePass fwrite encryptedBuffer");
+                return errno;
             }
         }
     } else {
@@ -1783,8 +1746,8 @@ int deletePass(FILE* dbFile, char* searchString)
         if (returnVal != fileSize - ((BUFFER_SIZES * 2) * entriesMatched) / sizeof(unsigned char))
         {
             if (ferror(tmpFile)) {
-                printf("fwrite failed @ 1558\n");
-                return 1;
+                perror("deletePass fwrite encryptedBuffer");
+                return errno;
             }
         }
     }
@@ -1818,8 +1781,8 @@ int updateEncPass(FILE* dbFile)
     returnVal = fread(encryptedBuffer, sizeof(unsigned char), fileSize, dbFile);
     if (returnVal != fileSize / sizeof(unsigned char)) {
         if (ferror(dbFile)) {
-            printf("Fread failed in updateEncPass()\n");
-            return 1;
+            perror("updateEncPass fread encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1834,8 +1797,7 @@ int updateEncPass(FILE* dbFile)
 
         free(decryptedBuffer);
         free(encryptedBuffer);
-        cleanUpFiles();
-        cleanUpBuffers();
+
         return 1;
     }
 
@@ -1916,7 +1878,8 @@ int updateEncPass(FILE* dbFile)
     tmpFile = fopen(tmpFile3, "wb"); /*Now open a temp file just to write the new evp1 data to, clean up in the calling function*/
     if (tmpFile == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
+        perror("updateEncPass tmpFile3");
+        printf("Couldn't open file: %s\n", tmpFile3);
         return errno;
     }
     chmod(tmpFile3, S_IRUSR | S_IWUSR);
@@ -1925,8 +1888,8 @@ int updateEncPass(FILE* dbFile)
     if (returnVal != fileSize / sizeof(unsigned char))
     {
         if (ferror(tmpFile)) {
-            printf("fwrite failed @ 1707\n");
-            return 1;
+            perror("updateEncPass fwrite encryptedBuffer");
+            return errno;
         }
     }
     fclose(tmpFile);
@@ -1969,8 +1932,8 @@ int writePass(FILE* dbFile)
     returnVal = fread(encryptedBuffer, sizeof(unsigned char), fileSize, dbFile);
     if (returnVal != fileSize / sizeof(unsigned char)) {
         if (ferror(dbFile)) {
-            printf("Fread failed in writePass()\n");
-            return 1;
+            perror("writePass fread encryptedBuffer");
+            return errno;
         }
     }
 
@@ -1989,8 +1952,7 @@ int writePass(FILE* dbFile)
             free(infoBuffer);
             free(decryptedBuffer);
             free(encryptedBuffer);
-            cleanUpFiles();
-            cleanUpBuffers();
+
             return 1;
         }
 
@@ -2007,8 +1969,7 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
+
             return 1;
         }
         /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -2025,8 +1986,7 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
+  
             return 1;
         }
         outlen += tmplen;
@@ -2047,8 +2007,7 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
+
             return 1;
         }
         /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -2064,8 +2023,7 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
+
             return 1;
         }
         outlen += tmplen;
@@ -2083,8 +2041,8 @@ int writePass(FILE* dbFile)
         if (returnVal != outlen * sizeof(unsigned char))
         {
             if (ferror(dbFile)) {
-                printf("fwrite failed @ 1837\n");
-                return 1;
+                perror("writePass fwrite outbuf");
+                return errno;
             }
         }
 
@@ -2113,8 +2071,7 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
+
             return 1;
         }
         /* Buffer passed to EVP_EncryptFinal() must be after data just
@@ -2129,8 +2086,6 @@ int writePass(FILE* dbFile)
             free(encryptedBuffer);
             free(ctx);
 
-            cleanUpFiles();
-            cleanUpBuffers();
             return 1;
         }
         outlen += tmplen;
@@ -2148,8 +2103,8 @@ int writePass(FILE* dbFile)
         if (returnVal != outlen * sizeof(unsigned char))
         {
             if (ferror(dbFile)) {
-                printf("fwrite failed @ 1881\n");
-                return 1;
+                perror("writePass fwrite encryptedBuffer");
+                return errno;
             }
         }
     }
@@ -2176,7 +2131,8 @@ int wipeFile(const char* filename)
         fileToWrite = fopen(filename, "w+");
         if (fileToWrite == NULL) /*Make sure the file opens*/
         {
-            perror("passmanager");
+            perror("wipeFile");
+            printf("Couldn't open file: %s\n", filename);
             return errno;
         }
         if (ii == 0) {
@@ -2243,8 +2199,8 @@ int dbEncrypt(FILE* in, FILE* out)
         if (returnValLocal != outlen)
         {
             if (ferror(out)) {
-                printf("fwrite failed 1975\n");
-                return 1;
+                perror("dbEncrypt fwrite outbuf");
+                return errno;
             }
         }
     }
@@ -2257,8 +2213,8 @@ int dbEncrypt(FILE* in, FILE* out)
     if (returnValLocal != outlen)
     {
         if (ferror(out)) {
-            printf("fwrite failed 1987\n");
-            return 1;
+            perror("dbEncrypt fwrite outbuf");
+            return errno;
         }
     }
     EVP_CIPHER_CTX_cleanup(ctx);
@@ -2292,8 +2248,8 @@ int dbDecrypt(FILE* in, FILE* out)
         if (returnValLocal != outlen)
         {
             if (ferror(out)) {
-                printf("fwrite failed @ 2018\n");
-                return 1;
+                perror("dbDecrypt fwrite outbuf");
+                return errno;
             }
         }
     }
@@ -2306,8 +2262,8 @@ int dbDecrypt(FILE* in, FILE* out)
     if (returnValLocal != outlen)
     {
         if (ferror(out)) {
-            printf("fwrite failed @ 2030\n");
-            return 1;
+            perror("dbDecrypt fwrite outbuf");
+            return errno;
         }
     }
     EVP_CIPHER_CTX_cleanup(ctx);
@@ -2490,8 +2446,7 @@ int sealEnvelope(const char* tmpFileToUse)
     
     if (!RAND_bytes(cryptoBufferPadding, BUFFER_SIZES)) {
         printf("Failure: CSPRNG bytes could not be made unpredictable\n");
-        cleanUpBuffers();
-        cleanUpFiles();
+
         exit(1);
     }
     memcpy(cryptoBuffer,cryptoBufferPadding,sizeof(char) * BUFFER_SIZES);
@@ -2501,7 +2456,8 @@ int sealEnvelope(const char* tmpFileToUse)
     /*Generate MAC from EVP1Data written to temp file*/
     EVP1DataFileTmp = fopen(tmpFileToUse, "rb");
     if (EVP1DataFileTmp == NULL) {
-        perror("passmanager");
+        perror("sealEnvelope fopen tmpFileToUse");
+        printf("Couldn't open file: %s\n", tmpFileToUse);
         return errno;
     }
     chmod(tmpFileToUse, S_IRUSR | S_IWUSR);
@@ -2512,7 +2468,8 @@ int sealEnvelope(const char* tmpFileToUse)
     EVP1DataFileTmp = fopen(tmpFileToUse, "ab");
     if (EVP1DataFileTmp == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
+        perror("sealEnvelope fopen tmpFileToUse");
+        printf("Couldn't open file: %s\n", tmpFileToUse);
         return errno;
     }
     chmod(tmpFileToUse, S_IRUSR | S_IWUSR);
@@ -2522,8 +2479,8 @@ int sealEnvelope(const char* tmpFileToUse)
     if (returnVal != SHA512_DIGEST_LENGTH / sizeof(unsigned char))
     {
         if (ferror(EVP1DataFileTmp)) {
-            printf("fwrite failed @ 2148\n");
-            return 1;
+            perror("sealEnvelope: fwrite gMac");
+            return errno;
         }
     }
     fclose(EVP1DataFileTmp);
@@ -2531,7 +2488,8 @@ int sealEnvelope(const char* tmpFileToUse)
     /*Open EVP1 file for reading, so we can use OpenSSL to encrypt it into the final password database file*/
     EVP2DecryptedFile = fopen(tmpFileToUse, "rb");
     if (EVP2DecryptedFile == NULL) {
-        perror("passmanager");
+        perror("sealEnvelope fopen tmpFileToUse");
+        printf("Couldn't open file: %s\n", tmpFileToUse);
         return errno;
     }
     chmod(tmpFileToUse, S_IRUSR | S_IWUSR);
@@ -2539,7 +2497,8 @@ int sealEnvelope(const char* tmpFileToUse)
     /*This will now be an EVP2EncryptedFile but calling it dbFile to clarify it is the final step*/
     dbFile = fopen(dbFileName, "wb");
     if (dbFile == NULL) {
-        perror("passmanager");
+        perror("sealEnvelope fopen dbFileName");
+        printf("Couldn't open file: %s\n", dbFileName);
         return errno;
     }
 
@@ -2558,8 +2517,8 @@ int sealEnvelope(const char* tmpFileToUse)
     if (returnVal != EVP2_SALT_SIZE / sizeof(unsigned char))
     {
         if (ferror(dbFile)) {
-            printf("fwrite failed @ 2184\n");
-            return 1;
+            perror("sealEnvelope fwrite evp2Salt");
+            return errno;
         }
     }
 
@@ -2568,8 +2527,8 @@ int sealEnvelope(const char* tmpFileToUse)
     if (returnVal != EVP1_SALT_SIZE / sizeof(unsigned char))
     {
         if (ferror(dbFile)) {
-            printf("fwrite failed 2 2192\n");
-            return 1;
+            perror("sealEnvelope fwrite evp1Salt");
+            return errno;
         }
     }
 
@@ -2578,8 +2537,8 @@ int sealEnvelope(const char* tmpFileToUse)
     if (returnVal != BUFFER_SIZES / sizeof(unsigned char))
     {
         if (ferror(dbFile)) {
-            printf("fwrite failed @ 2200\n");
-            return 1;
+            perror("sealEnvelope fwrite cryptoBuffer");
+            return errno;
         }
     }
 
@@ -2600,9 +2559,6 @@ int sealEnvelope(const char* tmpFileToUse)
     fclose(EVP2DecryptedFile);
     fclose(dbFile);
 
-    /*Cleanup temp files*/
-    cleanUpFiles();
-
     return 0;
 }
 
@@ -2622,7 +2578,8 @@ int openEnvelope()
     EVP2EncryptedFile = fopen(dbFileName, "rb");
     if (EVP2EncryptedFile == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
+        perror("openEnvelope fopen dbFileName");
+        printf("Couldn't open file: %s\n", dbFileName);
         return errno;
     }
 
@@ -2635,16 +2592,16 @@ int openEnvelope()
     returnVal = fread(evp2Salt, sizeof(char), EVP2_SALT_SIZE, EVP2EncryptedFile);
     if (returnVal != EVP2_SALT_SIZE / sizeof(char)) {
         if (ferror(EVP2EncryptedFile)) {
-            printf("Fread failed\n");
-            return 1;
+            perror("openEnvelope fread evp2Salt");
+            return errno;
         }
     }
 
     returnVal = fread(evp1Salt, sizeof(char), EVP1_SALT_SIZE, EVP2EncryptedFile);
     if (returnVal != EVP1_SALT_SIZE / sizeof(char)) {
         if (ferror(EVP2EncryptedFile)) {
-            printf("Fread failed\n");
-            return 1;
+            perror("openEnvelope fread evp1Salt");
+            return errno;
         }
     }
 
@@ -2655,8 +2612,8 @@ int openEnvelope()
     returnVal = fread(cryptoHeader, sizeof(char), BUFFER_SIZES, EVP2EncryptedFile);
     if (returnVal != BUFFER_SIZES / sizeof(char)) {
         if (ferror(EVP2EncryptedFile)) {
-            printf("Fread failed\n");
-            return 1;
+            perror("openEnvelope fread cryptoBuffer");
+            return errno;;
         }
     }
 
@@ -2673,7 +2630,6 @@ int openEnvelope()
     token = strtok(NULL, ":");
     if (token == NULL) {
         printf("Could not parse header.\nIs %s a password file?\n", dbFileName);
-        cleanUpFiles();
         exit(1);
     }
 
@@ -2683,7 +2639,6 @@ int openEnvelope()
     token = strtok(NULL, ":");
     if (token == NULL) {
         printf("Could not parse header.\nIs %s a password file?\n", dbFileName);
-        cleanUpFiles();
         exit(1);
     }
 
@@ -2742,8 +2697,8 @@ int openEnvelope()
     EVP1DataFileTmp = fopen(tmpFile1, "wb");
     if (EVP1DataFileTmp == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
-        printf("Could not open file: %s", tmpFile1);
+        perror("openEnvelope fopen tmpFile1");
+        printf("Couldn't open file: %s\n", tmpFile1);
         return errno;
     }
     chmod(tmpFile1, S_IRUSR | S_IWUSR);
@@ -2766,8 +2721,8 @@ int openEnvelope()
     EVP2DecryptedFile = fopen(tmpFile1, "rb");
     if (EVP2DecryptedFile == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
-        printf("Could not open file: %s", tmpFile1);
+        perror("openEnvelope fopen tmpFile1");
+        printf("Couldn't open file: %s\n", tmpFile1);
         return errno;
     }
     chmod(tmpFile1, S_IRUSR | S_IWUSR);
@@ -2776,7 +2731,8 @@ int openEnvelope()
     EVP1DataFileTmp = fopen(tmpFile2, "wb");
     if (EVP1DataFileTmp == NULL) /*Make sure the file opens*/
     {
-        perror("passmanager");
+        perror("openEnvelope fopen tmpFile2");
+        printf("Couldn't open file: %s\n", tmpFile2);
         return errno;
     }
     chmod(tmpFile2, S_IRUSR | S_IWUSR);
@@ -2794,8 +2750,8 @@ int openEnvelope()
     returnVal = fread(fMac, sizeof(char), SHA512_DIGEST_LENGTH, EVP2DecryptedFile);
     if (returnVal != SHA512_DIGEST_LENGTH / sizeof(char)) {
         if (ferror(EVP2DecryptedFile)) {
-            printf("Fread failed\n");
-            return 1;
+            perror("openEnvelope fread fMac");
+            return errno;
         }
     }
 
@@ -2809,8 +2765,8 @@ int openEnvelope()
     returnVal = fread(tmpBuffer, sizeof(char), fileSize - SHA512_DIGEST_LENGTH, EVP2DecryptedFile);
     if (returnVal != fileSize - SHA512_DIGEST_LENGTH / sizeof(char)) {
         if (ferror(EVP2DecryptedFile)) {
-            printf("Fread failed\n");
-            return 1;
+            perror("openEnvelope fread tmpBuffer");
+            return errno;
         }
     }
 
@@ -2818,8 +2774,8 @@ int openEnvelope()
     if (returnVal != fileSize - SHA512_DIGEST_LENGTH / sizeof(char))
     {
         if (ferror(EVP1DataFileTmp)) {
-            printf("fwrite failed @ 2411\n");
-            return 1;
+            perror("openEnvelope fwrite tmpBuffer");
+            return errno;
         }
     }
 
@@ -2955,17 +2911,13 @@ void allocateBuffers()
 /*Fill up the buffers we stored the information in with 0's before exiting*/
 void cleanUpBuffers()
 {
+
     OPENSSL_cleanse(entryPass, sizeof(char) * BUFFER_SIZES);
-    OPENSSL_cleanse(entryName, sizeof(char) * BUFFER_SIZES);
-    OPENSSL_cleanse(entryNameToSearch, sizeof(char) * BUFFER_SIZES);
-    OPENSSL_cleanse(newEntry, sizeof(char) * BUFFER_SIZES);
     OPENSSL_cleanse(newEntryPass, sizeof(char) * BUFFER_SIZES);
     OPENSSL_cleanse(dbPass, sizeof(unsigned char) * strlen(dbPass));
     OPENSSL_cleanse(dbPassOld, sizeof(unsigned char) * BUFFER_SIZES * 2);
     OPENSSL_cleanse(evpKey2, sizeof(unsigned char) * EVP_MAX_KEY_LENGTH);
     OPENSSL_cleanse(evpIv2, sizeof(unsigned char) * EVP_MAX_IV_LENGTH);
-    OPENSSL_cleanse(fMac, sizeof(unsigned char) * SHA512_DIGEST_LENGTH);
-    OPENSSL_cleanse(gMac, sizeof(unsigned char) * SHA512_DIGEST_LENGTH);
 }
 
 /*This function generates a random passsword if 'gen' is given as the entry's password*/
@@ -2980,8 +2932,7 @@ void genPassWord(int stringLength)
         /*Gets a random byte from OpenSSL PRNG*/
         if (!RAND_bytes(&b, 1)) {
             printf("Failure: CSPRNG bytes could not be made unpredictable\n");
-            cleanUpBuffers();
-            cleanUpFiles();
+
             exit(1);
         }
 
@@ -3050,8 +3001,7 @@ void genEvp2Salt()
     while (i < EVP2_SALT_SIZE) {
         if (!RAND_bytes(&b, 1)) {
             printf("Failure: CSPRNG bytes could not be made unpredictable\n");
-            cleanUpBuffers();
-            cleanUpFiles();
+
             exit(1);
             ;
         }
@@ -3069,8 +3019,7 @@ void genEvp1Salt()
     while (i < EVP1_SALT_SIZE) {
         if (!RAND_bytes(&b, 1)) {
             printf("Failure: CSPRNG bytes could not be made unpredictable\n");
-            cleanUpBuffers();
-            cleanUpFiles();
+
             exit(1);
         }
         evp1Salt[i] = b;
@@ -3085,28 +3034,32 @@ int sendToClipboard(char* textToSend)
     char xclipCommand[] = "xclip -in";
     char wipeCommand[] = "xclip -in";
     char wipeOutBuffer[strlen(textToSend)];
+    char *passBuffer = calloc(sizeof(char), strlen(textToSend));
     OPENSSL_cleanse(wipeOutBuffer, strlen(textToSend));
     FILE* xclipFile = popen(xclipCommand, "w");
     FILE* wipeFile = popen(wipeCommand, "w");
     pid_t pid, sid;
+    
+    strncpy(passBuffer,textToSend,strlen(textToSend));
 
     if (xclipFile == NULL) {
         perror("xclip");
         return errno;
     }
-    returnVal = fwrite(textToSend, sizeof(char), strlen(textToSend), xclipFile);
-    if (returnVal != strlen(textToSend) / sizeof(char))
+    returnVal = fwrite(passBuffer, sizeof(char), strlen(passBuffer), xclipFile);
+    if (returnVal != strlen(passBuffer) / sizeof(char))
     {
         if (ferror(xclipFile)) {
-            printf("fwrite failed @ 2640\n");
-            return 1;
+            perror("xclip");
+			return errno;
         }
     }
     if (pclose(xclipFile) == -1) {
         perror("xclip");
         return errno;
     }
-    OPENSSL_cleanse(textToSend, strlen(textToSend));
+    OPENSSL_cleanse(passBuffer, strlen(passBuffer));
+    OPENSSL_cleanse(textToSend,strlen(textToSend));
 
     printf("\n%i seconds before password is cleared from clipboard\n", xclipClearTime);
 
@@ -3138,15 +3091,17 @@ int sendToClipboard(char* textToSend)
     signal(SIGHUP, SIG_IGN);
 
     sid = setsid();
-
+    
+    cleanUpBuffers();
+    
     sleep(xclipClearTime);
 
-    returnVal = fwrite(wipeOutBuffer, sizeof(char), strlen(textToSend), wipeFile);
-    if (returnVal != strlen(textToSend) / sizeof(char))
+    returnVal = fwrite(wipeOutBuffer, sizeof(char), strlen(passBuffer), wipeFile);
+    if (returnVal != strlen(passBuffer) / sizeof(char))
     {
         if (ferror(wipeFile)) {
-            printf("fwrite failed @ 2684\n");
-            return 1;
+            perror("sendToClipboard fwrite wipeOutBuffer");
+            return errno;
         }
     }
 
@@ -3203,8 +3158,6 @@ void signalHandler(int signum)
     printf("\nCaught signal %d\n\nCleaning up temp files...\nCleaning up buffers...\n", signum);
     // Cleanup and close up stuff here
 
-    cleanUpBuffers();
-    cleanUpFiles();
 
     /* Restore terminal. */
     (void)tcsetattr(fileno(stdin), TCSAFLUSH, &termisOld);
@@ -3226,8 +3179,7 @@ char* getPass(const char* prompt, char* paddedPass)
         printf("Failure: CSPRNG bytes could not be made unpredictable\n");
         /* Restore terminal. */
         (void)tcsetattr(fileno(stdin), TCSAFLUSH, &termisOld);
-        cleanUpBuffers();
-        cleanUpFiles();
+
         printf("\nPassword was too large\n");
         exit(1);
     }
@@ -3253,8 +3205,7 @@ char* getPass(const char* prompt, char* paddedPass)
         (void)tcsetattr(fileno(stdin), TCSAFLUSH, &termisOld);
         OPENSSL_cleanse(pass, sizeof(char) * nread);
         free(pass);
-        cleanUpBuffers();
-        cleanUpFiles();
+
         printf("\nPassword was too large\n");
         exit(1);
     } else {
@@ -3330,7 +3281,7 @@ int printSyntax(char* arg)
 \n     \t-x 'database password' (the current database password to decrypt/with) \
 \n     \t-c 'first-cipher:second-cipher' - Update algorithms in cascade\
 \n     \t-H 'first-digest:second-digest' - Update digests used for cascaded algorithms' KDFs\
-\nVersion 2.2.1\
+\nVersion 2.2.2\
 \n\
 ",
         arg);


### PR DESCRIPTION
Unneeded cleanup functions calls were removed after clean-up routines registered with atexit().
sendToClipBoard also changed to clear sensitive buffers which were copied from the fork() from the main process.
Clearer error messages used in perror() calls