### PR TITLE
Compare 2.2.2 to kennbr34-patch-1

### DIFF
--- a/src/passmanager.c
+++ b/src/passmanager.c
@@ -2450,6 +2450,7 @@ int sealEnvelope(const char* tmpFileToUse)
         exit(1);
     }
     memcpy(cryptoBuffer,cryptoBufferPadding,sizeof(char) * BUFFER_SIZES);
+    free(cryptoBufferPadding);
     
     FILE *EVP2DecryptedFile, *EVP1DataFileTmp, *dbFile;
 
@@ -2906,6 +2907,8 @@ void allocateBuffers()
 
     evp1Salt = calloc(sizeof(unsigned char), EVP1_SALT_SIZE);
     evp2Salt = calloc(sizeof(unsigned char), EVP2_SALT_SIZE);
+    
+    free(tmpBuffer);
 }
 
 /*Fill up the buffers we stored the information in with 0's before exiting*/
@@ -2915,7 +2918,7 @@ void cleanUpBuffers()
     OPENSSL_cleanse(entryPass, sizeof(char) * BUFFER_SIZES);
     OPENSSL_cleanse(newEntryPass, sizeof(char) * BUFFER_SIZES);
     OPENSSL_cleanse(dbPass, sizeof(unsigned char) * strlen(dbPass));
-    OPENSSL_cleanse(dbPassOld, sizeof(unsigned char) * BUFFER_SIZES * 2);
+    OPENSSL_cleanse(dbPassOld, sizeof(unsigned char) * BUFFER_SIZES);
     OPENSSL_cleanse(evpKey2, sizeof(unsigned char) * EVP_MAX_KEY_LENGTH);
     OPENSSL_cleanse(evpIv2, sizeof(unsigned char) * EVP_MAX_IV_LENGTH);
 }
@@ -3104,6 +3107,7 @@ int sendToClipboard(char* textToSend)
             return errno;
         }
     }
+    free(passBuffer);
 
     exit(0);
 }


### PR DESCRIPTION
Compare 2.2.2 to kennbr34-patch-1 to see if that sheds some light on why wipeFile() causes segmentation fault in 2.2.2